### PR TITLE
Trigger of OnCeremonyPhaseChange in the sidechain

### DIFF
--- a/app-libs/stf/src/encointer_helpers.rs
+++ b/app-libs/stf/src/encointer_helpers.rs
@@ -15,10 +15,13 @@
 
 */
 
-use crate::AccountId;
+use crate::{helpers::get_storage_value, AccountId};
+use encointer_primitives::scheduler::CeremonyPhaseType;
 use frame_support::traits::EnsureOrigin;
+use itp_storage::storage_value_key;
 use itp_utils::stringify::account_id_to_string;
 use log::*;
+use std::prelude::v1::*;
 
 pub fn is_ceremony_master(account_id: AccountId) -> bool {
 	let origin = ita_sgx_runtime::Origin::signed(account_id.clone());
@@ -31,4 +34,12 @@ pub fn is_ceremony_master(account_id: AccountId) -> bool {
             false
         }
     }
+}
+
+pub fn current_ceremony_phase_storage_key() -> Vec<u8> {
+	storage_value_key("EncointerScheduler", "CurrentPhase")
+}
+
+pub fn current_ceremony_phase() -> Option<CeremonyPhaseType> {
+	get_storage_value("EncointerScheduler", "CurrentPhase")
 }

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -259,7 +259,7 @@ where
 			match CeremonyPhaseType::decode(&mut &*next_ceremony_phase) {
 				Ok(decoded_next_ceremony_phase) => {
 					if current_ceremony_phase.is_none()
-						|| decoded_next_ceremony_phase != current_ceremony_phase.unwrap_or_default()
+						|| decoded_next_ceremony_phase != current_ceremony_phase.unwrap()
 					{
 						info!(
 							"Current ceremony phase has changed: Phase is now {:?}",

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -253,10 +253,10 @@ where
 	State: SgxExternalitiesTrait,
 	Runtime: pallet_encointer_scheduler::Config + pallet_encointer_ceremonies::Config,
 {
-	fn update_ceremony_phase(state: &mut State, next_ceremony_phase: &[u8]) {
+	fn update_ceremony_phase(state: &mut State, next_ceremony_phase: &mut &[u8]) {
 		state.execute_with(|| {
 			let current_ceremony_phase = current_ceremony_phase();
-			match CeremonyPhaseType::decode(&mut &*next_ceremony_phase) {
+			match CeremonyPhaseType::decode(next_ceremony_phase) {
 				Ok(decoded_next_ceremony_phase) => {
 					if current_ceremony_phase.is_none()
 						|| decoded_next_ceremony_phase != current_ceremony_phase.unwrap()

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -255,10 +255,10 @@ where
 		+ pallet_encointer_scheduler::Config
 		+ pallet_encointer_ceremonies::Config,
 {
-	fn update_ceremony_phase(state: &mut State, next_ceremony_phase: &Vec<u8>) {
+	fn update_ceremony_phase(state: &mut State, next_ceremony_phase: &[u8]) {
 		state.execute_with(|| {
 			let current_ceremony_phase = current_ceremony_phase();
-			match CeremonyPhaseType::decode(&mut next_ceremony_phase.as_slice()) {
+			match CeremonyPhaseType::decode(&mut &*next_ceremony_phase) {
 				Ok(decoded_next_ceremony_phase) => {
 					if current_ceremony_phase.is_none()
 						|| decoded_next_ceremony_phase != current_ceremony_phase.unwrap()

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -263,7 +263,7 @@ where
 					if current_ceremony_phase.is_none()
 						|| decoded_next_ceremony_phase != current_ceremony_phase.unwrap()
 					{
-						debug!(
+						error!(
 							"Current ceremony phase has changed: Phase is now {:?}",
 							next_ceremony_phase
 						);

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -263,7 +263,7 @@ where
 					if current_ceremony_phase.is_none()
 						|| decoded_next_ceremony_phase != current_ceremony_phase.unwrap()
 					{
-						error!(
+						info!(
 							"Current ceremony phase has changed: Phase is now {:?}",
 							next_ceremony_phase
 						);

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -251,9 +251,7 @@ impl<Call, Getter, State, Runtime> EncointerSchedulerPalletInterface<State>
 	for Stf<Call, Getter, State, Runtime>
 where
 	State: SgxExternalitiesTrait,
-	Runtime: frame_system::Config
-		+ pallet_encointer_scheduler::Config
-		+ pallet_encointer_ceremonies::Config,
+	Runtime: pallet_encointer_scheduler::Config + pallet_encointer_ceremonies::Config,
 {
 	fn update_ceremony_phase(state: &mut State, next_ceremony_phase: &[u8]) {
 		state.execute_with(|| {

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -259,7 +259,7 @@ where
 			match CeremonyPhaseType::decode(&mut &*next_ceremony_phase) {
 				Ok(decoded_next_ceremony_phase) => {
 					if current_ceremony_phase.is_none()
-						|| decoded_next_ceremony_phase != current_ceremony_phase.unwrap()
+						|| decoded_next_ceremony_phase != current_ceremony_phase.unwrap_or_default()
 					{
 						info!(
 							"Current ceremony phase has changed: Phase is now {:?}",

--- a/app-libs/stf/src/trusted_call.rs
+++ b/app-libs/stf/src/trusted_call.rs
@@ -835,7 +835,6 @@ impl ExecuteCall for TrustedCallSigned {
 			| TrustedCall::ceremonies_unregister_participant(_, cid, _) => {
 			 */
 			TrustedCall::ceremonies_register_participant(_, cid, _) => {
-				key_hashes.push(storage_value_key("EncointerScheduler", "CurrentPhase"));
 				key_hashes.push(storage_value_key("EncointerScheduler", "CurrentCeremonyIndex"));
 				key_hashes.push(storage_value_key("EncointerCommunities", "CommunityIdentifiers"));
 				key_hashes.push(storage_map_key(
@@ -854,7 +853,6 @@ impl ExecuteCall for TrustedCallSigned {
 			/*
 			//get_aggregated_account_data ?
 			TrustedCall::ceremonies_attest_attendees(_, cid, _, ceremony_index, _) => {
-				key_hashes.push(storage_value_key("EncointerScheduler", "CurrentPhase"));
 				key_hashes.push(storage_value_key("EncointerScheduler", "PhaseDurations"));
 				key_hashes.push(storage_value_key("EncointerScheduler", "CurrentCeremonyIndex"));
 				key_hashes.push(storage_value_key("EncointerCommunities", "CommunityIdentifiers"));
@@ -868,7 +866,6 @@ impl ExecuteCall for TrustedCallSigned {
 				));
 			},
 			TrustedCall::ceremonies_claim_rewards(_, cid, _) => {
-				key_hashes.push(storage_value_key("EncointerScheduler", "CurrentPhase"));
 				key_hashes.push(storage_value_key("EncointerCommunities", "CommunityIdentifiers"));
 				key_hashes.push(storage_value_key("EncointerCommunities", "NominalIncome"));
 				key_hashes.push(storage_map_key(
@@ -878,11 +875,9 @@ impl ExecuteCall for TrustedCallSigned {
 					&StorageHasher::Blake2_128Concat,
 				));
 			},
-			TrustedCall::ceremonies_set_meetup_time_offset(_, _) => {
-				key_hashes.push(storage_value_key("EncointerScheduler", "CurrentPhase"));
-			},
+			TrustedCall::ceremonies_set_meetup_time_offset(_, _) =>
+				debug!("No storage updates needed..."),
 			TrustedCall::ceremonies_endorse_newcomer(_, cid, _) => {
-				key_hashes.push(storage_value_key("EncointerScheduler", "CurrentPhase"));
 				key_hashes.push(storage_value_key("EncointerScheduler", "CurrentCeremonyIndex"));
 				key_hashes.push(storage_value_key("EncointerCommunities", "CommunityIdentifiers"));
 				key_hashes.push(storage_map_key(

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -16,7 +16,9 @@
 */
 
 extern crate chrono;
-use crate::{base_cli::BaseCli, trusted_commands::TrustedArgs, Cli};
+use crate::{
+	base_cli::BaseCli, encointer_base_cli::EncointerBaseCli, trusted_commands::TrustedArgs, Cli,
+};
 use clap::Subcommand;
 
 #[cfg(feature = "teeracle")]
@@ -35,6 +37,9 @@ pub enum Commands {
 	#[cfg(feature = "teeracle")]
 	#[clap(subcommand)]
 	ExchangeOracle(ExchangeOracleSubCommand),
+
+	#[clap(flatten)]
+	EncointerBase(EncointerBaseCli),
 }
 
 pub fn match_command(cli: &Cli) {
@@ -43,5 +48,6 @@ pub fn match_command(cli: &Cli) {
 		Commands::Trusted(cmd) => cmd.run(cli),
 		#[cfg(feature = "teeracle")]
 		Commands::ExchangeOracle(cmd) => cmd.run(cli),
+		Commands::EncointerBase(cmd) => cmd.run(cli),
 	};
 }

--- a/cli/src/encointer_base_cli/commands/mod.rs
+++ b/cli/src/encointer_base_cli/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod next_phase;

--- a/cli/src/encointer_base_cli/commands/next_phase.rs
+++ b/cli/src/encointer_base_cli/commands/next_phase.rs
@@ -20,7 +20,6 @@ use crate::{
 	Cli,
 };
 
-use itp_types::OpaqueCall;
 use sp_core::{crypto::Ss58Codec, sr25519 as sr25519_core, Pair};
 use substrate_api_client::{compose_call, compose_extrinsic, UncheckedExtrinsicV4, XtStatus};
 

--- a/cli/src/encointer_base_cli/commands/next_phase.rs
+++ b/cli/src/encointer_base_cli/commands/next_phase.rs
@@ -1,0 +1,49 @@
+/*
+	Copyright 2022 Encointer Association
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{
+	command_utils::{get_chain_api, get_pair_from_str},
+	Cli,
+};
+
+use itp_types::OpaqueCall;
+use sp_core::{crypto::Ss58Codec, sr25519 as sr25519_core, Pair};
+use substrate_api_client::{compose_call, compose_extrinsic, UncheckedExtrinsicV4, XtStatus};
+
+#[derive(Debug, Clone, Parser)]
+pub struct NextPhaseCommand {
+	/// sender's AccountId in ss58check format
+	from: String,
+}
+
+impl NextPhaseCommand {
+	pub(crate) fn run(&self, cli: &Cli) {
+		let from_account = get_pair_from_str(&self.from);
+		println!("from ss58 is {}", from_account.public().to_ss58check());
+
+		let api = get_chain_api(cli).set_signer(sr25519_core::Pair::from(from_account.clone()));
+
+		let next_phase_call = compose_call!(api.metadata, "EncointerScheduler", "next_phase");
+
+		let xt: UncheckedExtrinsicV4<_, _> =
+			compose_extrinsic!(api, "Sudo", "sudo", next_phase_call);
+		// send and watch extrinsic until finalized
+		println!("Master {} trigger manually next phase ", from_account.public().to_ss58check());
+		let tx_hash = api.send_extrinsic(xt.hex_encode(), XtStatus::Finalized).unwrap();
+		println!("[+] Next Phase got finalized. Hash: {:?}\n", tx_hash);
+	}
+}

--- a/cli/src/encointer_base_cli/mod.rs
+++ b/cli/src/encointer_base_cli/mod.rs
@@ -1,0 +1,34 @@
+/*
+	Copyright 2022 Encointer Association
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{encointer_base_cli::commands::next_phase::NextPhaseCommand, Cli};
+
+mod commands;
+
+#[derive(Debug, clap::Subcommand)]
+pub enum EncointerBaseCli {
+	/// Manually transition to next phase
+	NextPhase(NextPhaseCommand),
+}
+
+impl EncointerBaseCli {
+	pub fn run(&self, cli: &Cli) {
+		match self {
+			EncointerBaseCli::NextPhase(cmd) => cmd.run(cli),
+		}
+	}
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -32,6 +32,7 @@ mod benchmark;
 mod ceremonies;
 mod command_utils;
 mod commands;
+mod encointer_base_cli;
 #[cfg(feature = "evm")]
 mod evm;
 #[cfg(feature = "teeracle")]
@@ -40,6 +41,7 @@ mod trusted_base_cli;
 mod trusted_command_utils;
 mod trusted_commands;
 mod trusted_operation;
+
 use crate::commands::Commands;
 use clap::Parser;
 

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -188,9 +188,7 @@ where
 		for shard_id in shards {
 			let (state_lock, mut state) = self.state_handler.load_for_mutation(&shard_id)?;
 			match Stf::update_parentchain_block(&mut state, header.clone()) {
-				Ok(_) => {
-					//self.state_handler.write_after_mutation(state, state_lock, &shard_id)?;
-				},
+				Ok(_) => {},
 				Err(e) => error!("Could not update parentchain block. {:?}: {:?}", shard_id, e),
 			}
 

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -183,15 +183,17 @@ where
 			.get_multiple_storages_verified(storage_hashes, header)
 			.map(into_map)?;
 
-		// Update parentchain block on all states.
+		// Update shards states.
 		let shards = self.state_handler.list_shards()?;
 		for shard_id in shards {
 			let (state_lock, mut state) = self.state_handler.load_for_mutation(&shard_id)?;
+			// Update parentchain block on all states.
 			match Stf::update_parentchain_block(&mut state, header.clone()) {
 				Ok(_) => {},
 				Err(e) => error!("Could not update parentchain block. {:?}: {:?}", shard_id, e),
 			}
 
+			// Update current_ceremony_phase storage for every shard, if it has changed on the parentchain.
 			if let Some(maybe_next_ceremony_phase) =
 				state_diff_update.get(&current_ceremony_phase_storage_key())
 			{

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -199,7 +199,10 @@ where
 			{
 				match maybe_next_ceremony_phase {
 					Some(encoded_next_ceremony_phase) => {
-						Stf::update_ceremony_phase(&mut state, encoded_next_ceremony_phase);
+						Stf::update_ceremony_phase(
+							&mut state,
+							&mut encoded_next_ceremony_phase.as_slice(),
+						);
 					},
 					_ => {
 						error!("no next ceremony phase in state diff !")

--- a/core-primitives/stf-interface/src/encointer_scheduler_pallet.rs
+++ b/core-primitives/stf-interface/src/encointer_scheduler_pallet.rs
@@ -18,5 +18,5 @@
 /// Interface trait of the encointer scheduler pallet.
 pub trait EncointerSchedulerPalletInterface<State> {
 	/// Updates the ceremony phase and if it has changed, call on_ceremony_phase_change
-	fn update_ceremony_phase(state: &mut State, next_ceremony_phase: &[u8]);
+	fn update_ceremony_phase(state: &mut State, next_ceremony_phase: &mut &[u8]);
 }

--- a/core-primitives/stf-interface/src/encointer_scheduler_pallet.rs
+++ b/core-primitives/stf-interface/src/encointer_scheduler_pallet.rs
@@ -21,5 +21,5 @@ use alloc::vec::Vec;
 /// Interface trait of the encointer scheduler pallet.
 pub trait EncointerSchedulerPalletInterface<State> {
 	/// Updates the ceremony phase and if it has changed, call on_ceremony_phase_change
-	fn update_ceremony_phase(state: &mut State, next_ceremony_phase: &Vec<u8>);
+	fn update_ceremony_phase(state: &mut State, next_ceremony_phase: &[u8]);
 }

--- a/core-primitives/stf-interface/src/encointer_scheduler_pallet.rs
+++ b/core-primitives/stf-interface/src/encointer_scheduler_pallet.rs
@@ -15,9 +15,6 @@
 
 */
 
-extern crate alloc;
-use alloc::vec::Vec;
-
 /// Interface trait of the encointer scheduler pallet.
 pub trait EncointerSchedulerPalletInterface<State> {
 	/// Updates the ceremony phase and if it has changed, call on_ceremony_phase_change

--- a/core-primitives/stf-interface/src/encointer_scheduler_pallet.rs
+++ b/core-primitives/stf-interface/src/encointer_scheduler_pallet.rs
@@ -1,0 +1,25 @@
+/*
+	Copyright 2022 Encointer Association
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+/// Interface trait of the encointer scheduler pallet.
+pub trait EncointerSchedulerPalletInterface<State> {
+	/// Updates the ceremony phase and if it has changed, call on_ceremony_phase_change
+	fn update_ceremony_phase(state: &mut State, next_ceremony_phase: &Vec<u8>);
+}

--- a/core-primitives/stf-interface/src/lib.rs
+++ b/core-primitives/stf-interface/src/lib.rs
@@ -25,6 +25,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 use itp_types::OpaqueCall;
 
+pub mod encointer_scheduler_pallet;
 #[cfg(feature = "mocks")]
 pub mod mocks;
 pub mod parentchain_pallet;


### PR DESCRIPTION
Fix issue #11 
- OnCeremonyPhaseChange is triggered when the current ceremony phase has changed.
  The current ceremony phase storage is updated upon block import. The update upon execution of trusted calls is no longer needed.
  The current ceremony phase storage is updated for every shard, if it has changed on the parentchain.
  **Note**: In the integritee-worker, the storage is currently only updated for new shards when blocks are imported. See https://github.com/integritee-network/worker/issues/1126 ->add a specific update for the current ceremony phase storage.
- Add a command to manually trigger the next ceremenoy phase on the node. This can be only called by SUDO
