### PR TITLE
Allow execution of public getters

### DIFF
--- a/core-primitives/stf-executor/src/getter_executor.rs
+++ b/core-primitives/stf-executor/src/getter_executor.rs
@@ -61,7 +61,7 @@ where
 		let getter_timer_start = Instant::now();
 		let state_result = self
 			.state_observer
-			.observe_state(shard, |state| StateGetter::get_state(&getter, state))??;
+			.observe_state(shard, |state| StateGetter::get_state(getter, state))??;
 
 		debug!("Getter executed in {} ms", getter_timer_start.elapsed().as_millis());
 
@@ -83,7 +83,7 @@ mod tests {
 
 	struct TestStateGetter;
 	impl GetState<TestState> for TestStateGetter {
-		fn get_state(_getter: &Getter, state: &mut TestState) -> Result<Option<Vec<u8>>> {
+		fn get_state(_getter: Getter, state: &mut TestState) -> Result<Option<Vec<u8>>> {
 			Ok(Some(state.encode()))
 		}
 	}

--- a/core-primitives/stf-executor/src/getter_executor.rs
+++ b/core-primitives/stf-executor/src/getter_executor.rs
@@ -106,7 +106,7 @@ mod tests {
 	}
 
 	#[test]
-	fn executing_public_getter_gives_error() {
+	fn executing_public_getter_works() {
 		let test_state = 23489u64;
 		let state_observer = Arc::new(TestStateObserver::new(test_state));
 		let getter_executor = TestGetterExecutor::new(state_observer);

--- a/core-primitives/stf-executor/src/mocks.rs
+++ b/core-primitives/stf-executor/src/mocks.rs
@@ -24,8 +24,7 @@ use crate::{
 use codec::Encode;
 use ita_stf::{
 	hash::{Hash, TrustedOperationOrHash},
-	AccountId, KeyPair, ShardIdentifier, TrustedCall, TrustedCallSigned, TrustedGetterSigned,
-	TrustedOperation,
+	AccountId, Getter, KeyPair, ShardIdentifier, TrustedCall, TrustedCallSigned, TrustedOperation,
 };
 use itp_sgx_externalities::SgxExternalitiesTrait;
 use itp_types::H256;
@@ -141,7 +140,7 @@ impl<StateType> GetState<StateType> for GetStateMock<StateType>
 where
 	StateType: Encode,
 {
-	fn get_state(_getter: &TrustedGetterSigned, state: &mut StateType) -> Result<Option<Vec<u8>>> {
+	fn get_state(_getter: &Getter, state: &mut StateType) -> Result<Option<Vec<u8>>> {
 		Ok(Some(state.encode()))
 	}
 }

--- a/core-primitives/stf-executor/src/mocks.rs
+++ b/core-primitives/stf-executor/src/mocks.rs
@@ -140,7 +140,7 @@ impl<StateType> GetState<StateType> for GetStateMock<StateType>
 where
 	StateType: Encode,
 {
-	fn get_state(_getter: &Getter, state: &mut StateType) -> Result<Option<Vec<u8>>> {
+	fn get_state(_getter: Getter, state: &mut StateType) -> Result<Option<Vec<u8>>> {
 		Ok(Some(state.encode()))
 	}
 }

--- a/core-primitives/stf-executor/src/state_getter.rs
+++ b/core-primitives/stf-executor/src/state_getter.rs
@@ -51,7 +51,7 @@ where
 		}
 
 		debug!("calling into STF to get state");
-		Ok(Stf::execute_getter(state, getter.clone().into()))
+		Ok(Stf::execute_getter(state, getter))
 	}
 }
 

--- a/core-primitives/stf-executor/src/state_getter.rs
+++ b/core-primitives/stf-executor/src/state_getter.rs
@@ -76,7 +76,7 @@ mod tests {
 		let mut state = SgxExternalities::default();
 
 		assert_matches!(
-			TestStateGetter::get_state(&signed_getter.into(), &mut state),
+			TestStateGetter::get_state(signed_getter.into(), &mut state),
 			Err(Error::OperationHasInvalidSignature)
 		);
 	}

--- a/core-primitives/stf-executor/src/state_getter.rs
+++ b/core-primitives/stf-executor/src/state_getter.rs
@@ -76,7 +76,7 @@ mod tests {
 		let mut state = SgxExternalities::default();
 
 		assert_matches!(
-			TestStateGetter::get_state(&signed_getter, &mut state),
+			TestStateGetter::get_state(&signed_getter.into(), &mut state),
 			Err(Error::OperationHasInvalidSignature)
 		);
 	}
@@ -87,6 +87,6 @@ mod tests {
 		let signed_getter =
 			TrustedGetter::free_balance(sender.public().into()).sign(&sender.into());
 		let mut state = SgxExternalities::default();
-		assert!(TestStateGetter::get_state(&signed_getter, &mut state).is_ok());
+		assert!(TestStateGetter::get_state(&signed_getter.into(), &mut state).is_ok());
 	}
 }

--- a/core-primitives/stf-executor/src/state_getter.rs
+++ b/core-primitives/stf-executor/src/state_getter.rs
@@ -29,7 +29,7 @@ pub trait GetState<StateType> {
 	///
 	/// Also verifies the signature of the trusted getter and returns an error
 	/// if it's invalid.
-	fn get_state(getter: &Getter, state: &mut StateType) -> Result<Option<Vec<u8>>>;
+	fn get_state(getter: Getter, state: &mut StateType) -> Result<Option<Vec<u8>>>;
 }
 
 pub struct StfStateGetter<Stf> {
@@ -40,8 +40,8 @@ impl<Stf> GetState<SgxExternalities> for StfStateGetter<Stf>
 where
 	Stf: StateGetterInterface<Getter, SgxExternalities>,
 {
-	fn get_state(getter: &Getter, state: &mut SgxExternalities) -> Result<Option<Vec<u8>>> {
-		if let Getter::trusted(getter) = getter {
+	fn get_state(getter: Getter, state: &mut SgxExternalities) -> Result<Option<Vec<u8>>> {
+		if let Getter::trusted(ref getter) = getter {
 			debug!("verifying signature of TrustedGetterSigned");
 			// FIXME: Trusted Getter should not be hardcoded. But
 			// verify_signature is currently not available as a Trait.
@@ -87,6 +87,6 @@ mod tests {
 		let signed_getter =
 			TrustedGetter::free_balance(sender.public().into()).sign(&sender.into());
 		let mut state = SgxExternalities::default();
-		assert!(TestStateGetter::get_state(&signed_getter.into(), &mut state).is_ok());
+		assert!(TestStateGetter::get_state(signed_getter.into(), &mut state).is_ok());
 	}
 }

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -482,6 +482,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +753,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "encointer-balances-tx-payment"
+version = "1.0.0"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
+dependencies = [
+ "encointer-primitives",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-asset-tx-payment",
+ "pallet-encointer-balances",
+ "pallet-encointer-ceremonies",
+ "pallet-transaction-payment",
+ "sp-runtime",
+]
+
+[[package]]
+name = "encointer-ceremonies-assignment"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
+dependencies = [
+ "encointer-primitives",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+]
+
+[[package]]
+name = "encointer-meetup-validation"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
+dependencies = [
+ "encointer-primitives",
+ "parity-scale-codec",
+ "scale-info",
+ "serde 1.0.145",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+]
+
+[[package]]
+name = "encointer-primitives"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
+dependencies = [
+ "bs58",
+ "crc",
+ "ep-core",
+ "geohash",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde 1.0.145",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.0"
 source = "git+https://github.com/integritee-network/env_logger-sgx#55745829b2ae8a77f0915af3671ec8a9a00cace9"
@@ -761,6 +834,22 @@ name = "environmental"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
+
+[[package]]
+name = "ep-core"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
+dependencies = [
+ "impl-serde",
+ "parity-scale-codec",
+ "scale-info",
+ "serde 1.0.145",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "substrate-fixed",
+]
 
 [[package]]
 name = "ethbloom"
@@ -1227,6 +1316,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "geohash"
+version = "0.13.0"
+source = "git+https://github.com/encointer/geohash?tag=v0.13.0#ad60d861f6bdbfd96ee9318f82554a7bec3089af"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "substrate-fixed",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "git+https://github.com/mesalock-linux/getrandom-sgx#0aa9cc20c7dea713ccaac2c44430d625a395ebae"
@@ -1451,13 +1550,20 @@ dependencies = [
 name = "ita-sgx-runtime"
 version = "0.9.0"
 dependencies = [
+ "encointer-balances-tx-payment",
+ "encointer-primitives",
  "frame-executive",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
  "itp-sgx-runtime-primitives",
+ "pallet-asset-tx-payment",
  "pallet-aura",
  "pallet-balances",
+ "pallet-encointer-balances",
+ "pallet-encointer-ceremonies",
+ "pallet-encointer-communities",
+ "pallet-encointer-scheduler",
  "pallet-evm",
  "pallet-grandpa",
  "pallet-parentchain",
@@ -1486,6 +1592,7 @@ name = "ita-stf"
 version = "0.9.0"
 dependencies = [
  "derive_more",
+ "encointer-primitives",
  "frame-support",
  "frame-system",
  "ita-sgx-runtime",
@@ -1499,6 +1606,9 @@ dependencies = [
  "its-state",
  "log",
  "pallet-balances",
+ "pallet-encointer-balances",
+ "pallet-encointer-ceremonies",
+ "pallet-encointer-scheduler",
  "pallet-parentchain",
  "pallet-sudo",
  "parity-scale-codec",
@@ -2707,6 +2817,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "pallet-asset-tx-payment"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f29353e89fc3e59d447041bb29622def3f"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-transaction-payment",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+]
+
+[[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f29353e89fc3e59d447041bb29622def3f"
@@ -2745,6 +2871,79 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+]
+
+[[package]]
+name = "pallet-encointer-balances"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
+dependencies = [
+ "encointer-primitives",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-asset-tx-payment",
+ "pallet-transaction-payment",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+]
+
+[[package]]
+name = "pallet-encointer-ceremonies"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
+dependencies = [
+ "encointer-ceremonies-assignment",
+ "encointer-meetup-validation",
+ "encointer-primitives",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-encointer-balances",
+ "pallet-encointer-communities",
+ "pallet-encointer-scheduler",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+]
+
+[[package]]
+name = "pallet-encointer-communities"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
+dependencies = [
+ "encointer-primitives",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-encointer-balances",
+ "pallet-encointer-scheduler",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+]
+
+[[package]]
+name = "pallet-encointer-scheduler"
+version = "1.1.0"
+source = "git+https://github.com/encointer/pallets?branch=master#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
+dependencies = [
+ "encointer-primitives",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -4358,6 +4557,7 @@ source = "git+https://github.com/encointer/substrate-fixed?tag=v0.5.9#a4fb461aae
 dependencies = [
  "parity-scale-codec",
  "scale-info",
+ "serde 1.0.145",
  "typenum 1.16.0",
 ]
 
@@ -4572,7 +4772,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.5",
  "static_assertions",
 ]

--- a/enclave-runtime/src/test/state_getter_tests.rs
+++ b/enclave-runtime/src/test/state_getter_tests.rs
@@ -35,7 +35,7 @@ pub fn state_getter_works() {
 	let signed_getter = TrustedGetter::free_balance(sender.public().into()).sign(&sender.into());
 	let mut state = test_state();
 
-	let encoded_balance = TestStfStateGetter::get_state(&signed_getter.into(), &mut state)
+	let encoded_balance = TestStfStateGetter::get_state(signed_getter.into(), &mut state)
 		.unwrap()
 		.unwrap();
 

--- a/enclave-runtime/src/test/state_getter_tests.rs
+++ b/enclave-runtime/src/test/state_getter_tests.rs
@@ -35,8 +35,9 @@ pub fn state_getter_works() {
 	let signed_getter = TrustedGetter::free_balance(sender.public().into()).sign(&sender.into());
 	let mut state = test_state();
 
-	let encoded_balance =
-		TestStfStateGetter::get_state(&signed_getter.into(), &mut state).unwrap().unwrap();
+	let encoded_balance = TestStfStateGetter::get_state(&signed_getter.into(), &mut state)
+		.unwrap()
+		.unwrap();
 
 	let balance = Balance::decode(&mut encoded_balance.as_slice()).unwrap();
 

--- a/enclave-runtime/src/test/state_getter_tests.rs
+++ b/enclave-runtime/src/test/state_getter_tests.rs
@@ -36,7 +36,7 @@ pub fn state_getter_works() {
 	let mut state = test_state();
 
 	let encoded_balance =
-		TestStfStateGetter::get_state(&signed_getter, &mut state).unwrap().unwrap();
+		TestStfStateGetter::get_state(&signed_getter.into(), &mut state).unwrap().unwrap();
 
 	let balance = Balance::decode(&mut encoded_balance.as_slice()).unwrap();
 


### PR DESCRIPTION
Also divide the `ExecuteGetter` implementations to make the code more readable.