### PR TITLE
perform meetup: attest attendees and list attestees

### DIFF
--- a/app-libs/stf/src/trusted_call.rs
+++ b/app-libs/stf/src/trusted_call.rs
@@ -386,14 +386,6 @@ impl ExecuteCall for TrustedCallSigned {
 			) => {
 				let origin = ita_sgx_runtime::Origin::signed(who);
 
-				if pallet_encointer_scheduler::Pallet::<ita_sgx_runtime::Runtime>::current_phase()
-					!= CeremonyPhaseType::Attesting
-				{
-					return Err(Self::Error::Dispatch(
-						"attendees attestation can only be done during attesting phase".to_string(),
-					))
-				}
-
 				ita_sgx_runtime::EncointerCeremoniesCall::<Runtime>::attest_attendees {
 					cid,
 					number_of_participants_vote,
@@ -414,15 +406,6 @@ impl ExecuteCall for TrustedCallSigned {
 				if !is_private_community(&cid) {
 					return Err(Self::Error::Dispatch(
 						"cannot register the participant: community is not private! ".to_string(),
-					))
-				}
-
-				if pallet_encointer_scheduler::Pallet::<ita_sgx_runtime::Runtime>::current_phase()
-					== CeremonyPhaseType::Assigning
-				{
-					return Err(Self::Error::Dispatch(
-						"registering a participant can only be done during registering or attesting phase"
-							.to_string(),
 					))
 				}
 
@@ -496,14 +479,6 @@ impl ExecuteCall for TrustedCallSigned {
 					))
 				}
 
-				if pallet_encointer_scheduler::Pallet::<ita_sgx_runtime::Runtime>::current_phase()
-					!= CeremonyPhaseType::Registering
-				{
-					return Err(Self::Error::Dispatch(
-						"adding a location can only be done during the registering phase"
-							.to_string(),
-					))
-				}
 				ita_sgx_runtime::EncointerCommunitiesCall::<Runtime>::add_location {
 					cid,
 					location,

--- a/cli/demo_private_community.sh
+++ b/cli/demo_private_community.sh
@@ -74,13 +74,13 @@ echo "Reading MRENCLAVE from worker list: ${MRENCLAVE}"
 [[ -z $MRENCLAVE ]] && { echo "MRENCLAVE is empty. cannot continue" ; exit 1; }
 echo ""
 
-echo ""
-echo "* Try to register //Alice, but community is not private! "
-$CLIENT trusted --mrenclave ${MRENCLAVE} register-participant //Alice ${COMMUNITY_IDENTIFIER}
-echo ""
-echo "* Listing participants: There is no participants! "
-$CLIENT trusted --mrenclave ${MRENCLAVE} list-participants //Alice ${COMMUNITY_IDENTIFIER}
-echo ""
+# echo ""
+# echo "* Try to register //Alice, but community is not private! "
+# $CLIENT trusted --mrenclave ${MRENCLAVE} register-participant //Alice ${COMMUNITY_IDENTIFIER}
+# echo ""
+# echo "* Listing participants: There is no participants! "
+# $CLIENT trusted --mrenclave ${MRENCLAVE} list-participants //Alice ${COMMUNITY_IDENTIFIER}
+# echo ""
 
 echo ""
 echo "* Migrating community ${COMMUNITY_IDENTIFIER} to private"
@@ -88,7 +88,7 @@ $CLIENT trusted --mrenclave ${MRENCLAVE} make-community-private //Alice ${COMMUN
 echo ""
 
 echo ""
-echo "* Registering 3 bootstrapper : "
+echo "* Registering 3 bootstrappers : "
 echo "  //Alice,"
 $CLIENT trusted --mrenclave ${MRENCLAVE} register-participant //Alice ${COMMUNITY_IDENTIFIER}
 echo "  //Bob"
@@ -116,4 +116,36 @@ sleep 10
 echo ""
 echo "* Listing Meetups"
 $CLIENT trusted --mrenclave ${MRENCLAVE} list-meetups //Alice ${COMMUNITY_IDENTIFIER}
+echo ""
+
+echo ""
+echo "* Performing Meetups"
+
+echo ""
+echo "* Triggering manually next phase: Attesting"
+$CLIENT next-phase //Alice
+echo ""
+
+echo " //Alice's attest attendees claim"
+$CLIENT trusted --mrenclave ${MRENCLAVE} attest-attendees //Alice ${COMMUNITY_IDENTIFIER} //Bob //Charlie //Cora
+echo ""
+
+echo " //Bob's attest attendees claim"
+$CLIENT trusted --mrenclave ${MRENCLAVE} attest-attendees //Bob ${COMMUNITY_IDENTIFIER} //Alice //Charlie //Cora
+echo ""
+
+echo " //Charlie's attest attendees claim"
+$CLIENT trusted --mrenclave ${MRENCLAVE} attest-attendees //Charlie ${COMMUNITY_IDENTIFIER} //Alice //Bob //Cora
+echo ""
+
+echo " //Cora's attest attendees claim"
+$CLIENT trusted --mrenclave ${MRENCLAVE} attest-attendees //Cora ${COMMUNITY_IDENTIFIER} //Alice //Charlie //Bob
+echo ""
+
+echo "* Waiting enough time, such that xt's are processed... 3 blocks 30 seconds"
+sleep 30
+
+echo ""
+echo "* Listing Attestees"
+$CLIENT trusted --mrenclave ${MRENCLAVE} list-attestees //Alice ${COMMUNITY_IDENTIFIER}
 echo ""

--- a/cli/src/ceremonies/commands/attest_attendees.rs
+++ b/cli/src/ceremonies/commands/attest_attendees.rs
@@ -1,0 +1,81 @@
+/*
+	Copyright 2022 Encointer Association
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{
+	get_layer_two_nonce,
+	trusted_command_utils::{get_accountid_from_str, get_identifiers, get_pair_from_str},
+	trusted_commands::TrustedArgs,
+	trusted_operation::perform_trusted_operation,
+	Cli,
+};
+use codec::Decode;
+use encointer_primitives::communities::CommunityIdentifier;
+use ita_stf::{Index, KeyPair, TrustedCall, TrustedGetter, TrustedOperation};
+use log::*;
+use sp_core::Pair;
+use std::str::FromStr;
+
+/// Attest Encointer ceremony attendees claim for the supplied community
+#[derive(Debug, Clone, Parser)]
+pub struct AttestAttendeesCommand {
+	/// Participant : sender's on-chain AccountId in ss58check format.
+	who: String,
+
+	/// Community Id.
+	community_id: String,
+
+	/// Participants who attested: list of AccountIds in ss58check format.
+	#[structopt(min_values = 2)]
+	attestations: Vec<String>,
+}
+
+impl AttestAttendeesCommand {
+	pub fn run(&self, cli: &Cli, trusted_args: &TrustedArgs) {
+		let who = get_pair_from_str(trusted_args, &self.who);
+		let (mrenclave, shard) = get_identifiers(trusted_args);
+
+		info!(
+			"Attest attendees claim for community {} and participant {}",
+			self.community_id,
+			who.public()
+		);
+
+		let community_identifier = CommunityIdentifier::from_str(&self.community_id).unwrap();
+
+		let mut attestations = Vec::new();
+
+		for a in &self.attestations {
+			attestations.push(get_accountid_from_str(a));
+		}
+
+		let number_of_participants_vote = attestations.len() as u32 + 1u32;
+		info!("Number of  vote {}", number_of_participants_vote);
+
+		let nonce = get_layer_two_nonce!(who, cli, trusted_args);
+		let top = TrustedCall::ceremonies_attest_attendees(
+			who.public().into(),
+			community_identifier,
+			number_of_participants_vote,
+			attestations,
+		)
+		.sign(&KeyPair::Sr25519(who), nonce, &mrenclave, &shard)
+		.into_trusted_operation(trusted_args.direct);
+
+		let _ = perform_trusted_operation(cli, trusted_args, &top);
+		debug!("trusted call ceremonies_attest_attendees executed");
+	}
+}

--- a/cli/src/ceremonies/commands/ceremonies_command_utils.rs
+++ b/cli/src/ceremonies/commands/ceremonies_command_utils.rs
@@ -219,7 +219,7 @@ pub fn get_meetup_index(
 		get_aggregated_account_data(cli, trusted_args, arg_who, community_identifier, account_id)?;
 	match account_data.personal {
 		Some(personal) => Ok(personal.meetup_index),
-		None => return Err(Error::Other("No personal data in AggregatedAccountData".into())),
+		None => Err(Error::Other("No personal data in AggregatedAccountData".into())),
 	}
 }
 

--- a/cli/src/ceremonies/commands/list_attestees.rs
+++ b/cli/src/ceremonies/commands/list_attestees.rs
@@ -1,0 +1,214 @@
+/*
+	Copyright 2022 Encointer Association
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{
+	ceremonies::commands::ceremonies_command_utils::{
+		get_meetup_index, participant_attestation_index_map, AttestationState,
+	},
+	command_utils::get_chain_api,
+	trusted_command_utils::get_pair_from_str,
+	trusted_commands::TrustedArgs,
+	trusted_operation::perform_trusted_operation,
+	Cli,
+};
+use codec::Decode;
+use encointer_primitives::{ceremonies::AttestationIndexType, communities::CommunityIdentifier};
+use ita_stf::{KeyPair, PublicGetter, TrustedGetter, TrustedOperation};
+use itp_node_api::api_client::encointer::EncointerApi;
+use log::*;
+use sp_core::Pair;
+use std::{collections::HashMap, str::FromStr};
+
+/// Listing all attestees for participants for supplied community identifier and ceremony index.
+#[derive(Debug, Clone, Parser)]
+pub struct ListAttesteesCommand {
+	/// Participant : sender's on-chain AccountId in ss58check format.
+	who: String,
+
+	/// Community Id.
+	community_id: String,
+}
+
+impl ListAttesteesCommand {
+	pub fn run(&self, cli: &Cli, trusted_args: &TrustedArgs) {
+		let api = get_chain_api(cli);
+		let who = get_pair_from_str(trusted_args, &self.who);
+
+		let community_identifier = CommunityIdentifier::from_str(&self.community_id).unwrap();
+		let ceremony_index = api.get_current_ceremony_index(None).unwrap().unwrap();
+
+		println!(
+			"Listing all attestees for community {} and ceremony {}",
+			self.community_id, ceremony_index
+		);
+
+		let top: TrustedOperation =
+			PublicGetter::ceremonies_attestation_count(community_identifier, ceremony_index).into();
+		let encoded_attestee = perform_trusted_operation(cli, trusted_args, &top).unwrap();
+		let attestee_count =
+			AttestationIndexType::decode(&mut encoded_attestee.as_slice()).unwrap_or_default();
+		println!("number of attestees:  {}", attestee_count);
+
+		println!(
+			"Get attestation index for all participants of cid {} and ceremony nr {}",
+			community_identifier, ceremony_index
+		);
+
+		let mut participants_attestation_indexes = HashMap::new();
+
+		let top: TrustedOperation = TrustedGetter::ceremonies_registered_bootstrappers(
+			who.public().into(),
+			community_identifier,
+			ceremony_index,
+		)
+		.sign(&KeyPair::Sr25519(who.clone()))
+		.into();
+		match perform_trusted_operation(cli, trusted_args, &top) {
+			Some(encoded_bootstrappers) => {
+				participants_attestation_indexes.extend(participant_attestation_index_map(
+					cli,
+					trusted_args,
+					&self.who,
+					community_identifier,
+					ceremony_index,
+					encoded_bootstrappers,
+				));
+			},
+			None => println!("No bootstrappers registered for this ceremony"),
+		}
+
+		let top: TrustedOperation = TrustedGetter::ceremonies_registered_reputables(
+			who.public().into(),
+			community_identifier,
+			ceremony_index,
+		)
+		.sign(&KeyPair::Sr25519(who.clone()))
+		.into();
+		match perform_trusted_operation(cli, trusted_args, &top) {
+			Some(encoded_reputables) => {
+				participants_attestation_indexes.extend(participant_attestation_index_map(
+					cli,
+					trusted_args,
+					&self.who,
+					community_identifier,
+					ceremony_index,
+					encoded_reputables,
+				));
+			},
+			None => println!("No reputables registered for this ceremony"),
+		}
+
+		let top: TrustedOperation = TrustedGetter::ceremonies_registered_endorsees(
+			who.public().into(),
+			community_identifier,
+			ceremony_index,
+		)
+		.sign(&KeyPair::Sr25519(who.clone()))
+		.into();
+		match perform_trusted_operation(cli, trusted_args, &top) {
+			Some(encoded_endorsees) => {
+				participants_attestation_indexes.extend(participant_attestation_index_map(
+					cli,
+					trusted_args,
+					&self.who,
+					community_identifier,
+					ceremony_index,
+					encoded_endorsees,
+				));
+			},
+			None => println!("No endorsees registered for this ceremony"),
+		}
+
+		let top: TrustedOperation = TrustedGetter::ceremonies_registered_newbies(
+			who.public().into(),
+			community_identifier,
+			ceremony_index,
+		)
+		.sign(&KeyPair::Sr25519(who.clone()))
+		.into();
+		match perform_trusted_operation(cli, trusted_args, &top) {
+			Some(encoded_newbies) => {
+				participants_attestation_indexes.extend(participant_attestation_index_map(
+					cli,
+					trusted_args,
+					&self.who,
+					community_identifier,
+					ceremony_index,
+					encoded_newbies,
+				));
+			},
+			None => println!("No newbies registered for this ceremony"),
+		}
+
+		let mut attestation_states = Vec::with_capacity(attestee_count as usize);
+
+		for attestation_index in 1..attestee_count + 1 {
+			let attestor = participants_attestation_indexes[&attestation_index].clone();
+			info!("Create Attestation state for {:?}", attestor);
+			let meetup_index = get_meetup_index(
+				cli,
+				trusted_args,
+				&self.who,
+				community_identifier,
+				attestor.clone(),
+			)
+			.unwrap()
+			.unwrap();
+
+			let top: TrustedOperation = TrustedGetter::ceremonies_participant_attestees(
+				who.public().into(),
+				community_identifier,
+				ceremony_index,
+				attestation_index,
+			)
+			.sign(&KeyPair::Sr25519(who.clone()))
+			.into();
+			let encoded_index = perform_trusted_operation(cli, trusted_args, &top).unwrap();
+			let attestees = Decode::decode(&mut encoded_index.as_slice()).unwrap();
+
+			let top: TrustedOperation = TrustedGetter::ceremonies_meetup_participant_count_vote(
+				who.public().into(),
+				community_identifier,
+				ceremony_index,
+				attestor.clone(),
+			)
+			.sign(&KeyPair::Sr25519(who.clone()))
+			.into();
+			let encoded_count_vote =
+				perform_trusted_operation(cli, trusted_args, &top).unwrap_or_default();
+			let vote = Decode::decode(&mut encoded_count_vote.as_slice()).unwrap_or_default();
+
+			let attestation_state = AttestationState::new(
+				(community_identifier, ceremony_index),
+				meetup_index,
+				vote,
+				attestation_index,
+				attestor,
+				attestees,
+			);
+
+			attestation_states.push(attestation_state);
+		}
+
+		// Group attestation states by meetup index
+		attestation_states.sort_by(|a, b| a.meetup_index.partial_cmp(&b.meetup_index).unwrap());
+		println!("Attestees :");
+		for a in attestation_states.iter() {
+			println!("{:?}", a);
+		}
+	}
+}

--- a/cli/src/ceremonies/commands/list_attestees.rs
+++ b/cli/src/ceremonies/commands/list_attestees.rs
@@ -156,7 +156,7 @@ impl ListAttesteesCommand {
 
 		let mut attestation_states = Vec::with_capacity(attestee_count as usize);
 
-		for attestation_index in 1..attestee_count + 1 {
+		for attestation_index in 1..=attestee_count {
 			let attestor = participants_attestation_indexes[&attestation_index].clone();
 			info!("Create Attestation state for {:?}", attestor);
 			let meetup_index = get_meetup_index(

--- a/cli/src/ceremonies/commands/mod.rs
+++ b/cli/src/ceremonies/commands/mod.rs
@@ -15,7 +15,9 @@
 
 */
 
+pub mod attest_attendees;
 pub mod ceremonies_command_utils;
+pub mod list_attestees;
 pub mod list_meetups;
 pub mod list_participants;
 pub mod register_participant;

--- a/cli/src/ceremonies/mod.rs
+++ b/cli/src/ceremonies/mod.rs
@@ -17,6 +17,7 @@
 
 use crate::{
 	ceremonies::commands::{
+		attest_attendees::AttestAttendeesCommand, list_attestees::ListAttesteesCommand,
 		list_meetups::ListMeetupsCommand, list_participants::ListParticipantsCommand,
 		register_participant::RegisterParticipantCommand,
 		upgrade_registration::UpgradeRegistrationCommand,
@@ -29,10 +30,12 @@ mod commands;
 
 #[derive(Debug, clap::Subcommand)]
 pub enum CeremoniesCommands {
+	AttestAttendees(AttestAttendeesCommand),
 	RegisterParticipant(RegisterParticipantCommand),
 	UpgradeRegistration(UpgradeRegistrationCommand),
-	ListParticipants(ListParticipantsCommand),
+	ListAttestees(ListAttesteesCommand),
 	ListMeetups(ListMeetupsCommand),
+	ListParticipants(ListParticipantsCommand),
 	/*
 		CeremoniesUnregisterParticipant(),
 		CeremoniesAttestAttendees(),
@@ -53,10 +56,12 @@ pub enum CeremoniesCommands {
 impl CeremoniesCommands {
 	pub fn run(&self, cli: &Cli, trusted_args: &TrustedArgs) {
 		match self {
+			CeremoniesCommands::AttestAttendees(cmd) => cmd.run(cli, trusted_args),
 			CeremoniesCommands::RegisterParticipant(cmd) => cmd.run(cli, trusted_args),
 			CeremoniesCommands::UpgradeRegistration(cmd) => cmd.run(cli, trusted_args),
-			CeremoniesCommands::ListParticipants(cmd) => cmd.run(cli, trusted_args),
+			CeremoniesCommands::ListAttestees(cmd) => cmd.run(cli, trusted_args),
 			CeremoniesCommands::ListMeetups(cmd) => cmd.run(cli, trusted_args),
+			CeremoniesCommands::ListParticipants(cmd) => cmd.run(cli, trusted_args),
 		}
 	}
 }

--- a/enclave-runtime/src/test/ceremonies_test.rs
+++ b/enclave-runtime/src/test/ceremonies_test.rs
@@ -1,0 +1,48 @@
+/*
+	Copyright 2022 Encointer Association
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+pub fn test_register_bootstrapper() {
+	// given
+	let (_, mut state, shard, mrenclave, ..) = test_setup();
+	let mut opaque_vec = Vec::new();
+
+	// Create the sender account.
+	let sender = funded_pair();
+
+	//Update state
+	//Create the community
+	//Create a bootstrapper
+	//Set phase registering
+
+	//Call to register bootstrapper
+	let trusted_call = TrustedCall::ceremonies_register_participant(sender_acc, cid, None).sign(
+		&sender.clone().into(),
+		0,
+		&mrenclave,
+		&shard,
+	);
+
+	//execute call
+
+	//check
+	/*
+	let bootstrapper_count = state
+		.execute_with(|| get_evm_account_storages(&execution_address, &H256::zero()))
+		.unwrap();
+
+	 */
+}


### PR DESCRIPTION
Implement the attest attendees claim functionality. The trusted call can be executed only by Me. 
The success of it can be checked with the list-attendees cmd. This can aonly be called by the ceremony master.
Add in the demo the performing meetup step. This was run manually with success.



